### PR TITLE
fixed SwrFree (libswresample) segfault

### DIFF
--- a/swresample/context.go
+++ b/swresample/context.go
@@ -29,7 +29,7 @@ func (s *Context) SwrAllocSetOpts(ocl int64, osf AvSampleFormat, osr int, icl in
 
 //Context destructor functions. Free the given Context and set the pointer to NULL.
 func (s *Context) SwrFree() {
-	C.swr_free((**C.struct_SwrContext)(unsafe.Pointer(s)))
+	C.swr_free((**C.struct_SwrContext)(unsafe.Pointer(&s)))
 }
 
 //Closes the context so that swr_is_initialized() returns 0.


### PR DESCRIPTION
Hello, i found a bug causing SwrFree function from libswresample to segfault. Adding missing pointer fixes the issue.

Simplest code to reproduce the bug:
```go
package main

import (
	"github.com/asticode/goav/swresample"
)

func main() {
	ctx := swresample.SwrAlloc()

	ctx.SwrFree()
}
```